### PR TITLE
Removed old to string method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MetaModelica"
 uuid = "9d7f2a79-07b5-5542-8b19-c0100dda6b06"
 authors = ["Martin Sjölund <martin.sjolund@liu.se>", "John Tinnerholm <john.tinnerholm@liu.se>"]
-version = "0.0.2"
+version = "0.0.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/metaRuntime.jl
+++ b/src/metaRuntime.jl
@@ -795,7 +795,3 @@ end
 function StringFunction(r::Float64)::String
   realString(r)
 end
-
-function String(a)::String
-  string(a)
-end


### PR DESCRIPTION
This PR removes a method that invalidates a lot of Julia code. That is String(x)